### PR TITLE
Updated ScintillaNET reference to 3.6.3, fixes Visual Studio Designer…

### DIFF
--- a/EasyScintilla/EasyScintilla.csproj
+++ b/EasyScintilla/EasyScintilla.csproj
@@ -58,8 +58,8 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="ScintillaNET, Version=3.5.10.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\jacobslusser.ScintillaNET.3.5.10\lib\net40\ScintillaNET.dll</HintPath>
+    <Reference Include="ScintillaNET, Version=3.6.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\jacobslusser.ScintillaNET.3.6.3\lib\net40\ScintillaNET.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/EasyScintilla/Stylers/PowershellStyler.cs
+++ b/EasyScintilla/Stylers/PowershellStyler.cs
@@ -47,8 +47,8 @@ namespace EasyScintilla.Stylers
             scintilla.Styles[Style.PowerShell.HereString].ForeColor = ColorTranslator.FromHtml("#808080");
             scintilla.Styles[Style.PowerShell.HereString].BackColor = Color.White;
 
-            scintilla.Styles[Style.PowerShell.HereCharcter].ForeColor = ColorTranslator.FromHtml("#808080");
-            scintilla.Styles[Style.PowerShell.HereCharcter].BackColor = Color.White;
+            scintilla.Styles[Style.PowerShell.HereCharacter].ForeColor = ColorTranslator.FromHtml("#808080");
+            scintilla.Styles[Style.PowerShell.HereCharacter].BackColor = Color.White;
 
             scintilla.Styles[Style.PowerShell.CommentDocKeyword].ForeColor = ColorTranslator.FromHtml("#008080");
             scintilla.Styles[Style.PowerShell.CommentDocKeyword].BackColor = Color.White;

--- a/EasyScintilla/packages.config
+++ b/EasyScintilla/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="jacobslusser.ScintillaNET" version="3.5.10" targetFramework="net461" />
+  <package id="jacobslusser.ScintillaNET" version="3.6.3" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
Resolves issue #2 (on my machine at least). A reset of the toolbox and restart of Visual Studio were required to get it to quit trying to load ScintillaNET 3.5.10.